### PR TITLE
Record transcript and command execution times

### DIFF
--- a/Get-NetView.psm1
+++ b/Get-NetView.psm1
@@ -2109,7 +2109,7 @@ function Sanity {
     New-Item -ItemType directory -Path $dir | Out-Null
 
     $file = "Get-ChildItem.txt"
-    [String []] $cmds = "Get-ChildItem -Path $OutDir -Exclude $file -Recurse | Get-FileHash | Format-Table -AutoSize | Out-String -Width $columns"
+    [String []] $cmds = "Get-ChildItem -Path $OutDir -Exclude $file, Get-NetView.log -File -Recurse | Get-FileHash | Format-Table -AutoSize | Out-String -Width $columns"
     ExecCommands -OutDir $dir -File $file -Commands $cmds
 
     $file = "Metadata.txt"
@@ -2186,7 +2186,7 @@ function EnvCreate {
     try {
         New-Item -ItemType directory -Path $OutDir -ErrorAction Stop | Out-Null
     } catch {
-        throw "Get-NetView : Failed to create directory ""$OutDir"" because " + $error[0]
+        throw "Get-NetView : Failed to create directory ""$OutDir"" because " + $_
     }
 } # EnvCreate()
 
@@ -2202,6 +2202,8 @@ function Initialization {
     # Setup output folder
     EnvDestroy $OutDir
     EnvCreate $OutDir
+
+    Start-Transcript -Path "$OutDir\Get-NetView.log"
 
     Clear-Host
 } # Initialization()
@@ -2228,6 +2230,8 @@ function Completion {
     )
 
     $timestamp = $start | Get-Date -f yyyy.MM.dd_hh.mm.ss
+
+    Stop-Transcript
 
     # Zip output folder
     $outzip = "$Src-$timestamp.zip"

--- a/Get-NetView.psm1
+++ b/Get-NetView.psm1
@@ -114,7 +114,7 @@ $ExecFunctions = {
         }
         Write-Output "$commandOut"
 
-        Write-CmdLog $logMsg
+        Write-CmdLog "$logMsg"
     } # ExecCommand()
 
     function ExecCommands {
@@ -181,7 +181,7 @@ function TryCmd {
 function Write-CmdLog {
     [CmdletBinding()]
     Param(
-        [parameter(Mandatory=$false)] [String] $CmdLog
+        [parameter(Mandatory=$true)] [String] $CmdLog
     )
 
     $logColor = [ConsoleColor]::White
@@ -2109,7 +2109,7 @@ function Sanity {
     New-Item -ItemType directory -Path $dir | Out-Null
 
     $file = "Get-ChildItem.txt"
-    [String []] $cmds = "Get-ChildItem -Path $OutDir -Exclude $file, Get-NetView.log -File -Recurse | Get-FileHash | Format-Table -AutoSize | Out-String -Width $columns"
+    [String []] $cmds = "Get-ChildItem -Path $OutDir -Exclude Get-NetView.log -File -Recurse | Get-FileHash | Format-Table -AutoSize | Out-String -Width $columns"
     ExecCommands -OutDir $dir -File $file -Commands $cmds
 
     $file = "Metadata.txt"
@@ -2186,7 +2186,7 @@ function EnvCreate {
     try {
         New-Item -ItemType directory -Path $OutDir -ErrorAction Stop | Out-Null
     } catch {
-        throw "Get-NetView : Failed to create directory ""$OutDir"" because " + $_
+        throw "Get-NetView : Failed to create directory ""$OutDir"" because " + $error[0]
     }
 } # EnvCreate()
 

--- a/Get-NetView.psm1
+++ b/Get-NetView.psm1
@@ -45,7 +45,7 @@ $ExecFunctions = {
         NotTested    # Indicates problem with TestCommand
         Unavailable  # [Part of] the command doesn't exist
         Failed       # An error prevented successful execution
-        Succeeded    # No errors or exceptions
+        Success      # No errors or exceptions
     }
 
     # Powershell cmdlets have inconsistent implementations in command error handling. This function
@@ -57,6 +57,7 @@ $ExecFunctions = {
         )
 
         $status = [CommandStatus]::NotTested
+        $duration = [TimeSpan]::Zero
         $commandOut = ""
 
         try {
@@ -66,8 +67,10 @@ $ExecFunctions = {
             # Any errors will still be output to $error variable.
             $silentCmd = '$({0}) 2>$null 3>&1 4>&1 5>&1 6>&1' -f $Command
 
-            # ErrorAction MUST be Stop for try catch to work.
-            $commandOut = (Invoke-Expression $silentCmd -ErrorAction Stop)
+            $duration = Measure-Command {
+                # ErrorAction MUST be Stop for try catch to work.
+                $commandOut = (Invoke-Expression $silentCmd -ErrorAction Stop)
+            }
 
             # Sometimes commands output errors even on successful execution.
             # We only should fail commands if an error was their *only* output.
@@ -79,18 +82,18 @@ $ExecFunctions = {
                 }
             }
 
-            $status = [CommandStatus]::Succeeded
+            $status = [CommandStatus]::Success
         } catch [Management.Automation.CommandNotFoundException] {
             $status = [CommandStatus]::Unavailable
         } catch {
             $status  = [CommandStatus]::Failed
-            $commandOut = ($error[0] | Out-String)
+            $commandOut = ($_ | Out-String)
         } finally {
             # Post-execution cleanup to avoid false positives
             $error.Clear()
         }
 
-        return $status, $commandOut
+        return $status, $duration.TotalMilliseconds, $commandOut
     } # TestCommand()
 
     function ExecCommand {
@@ -99,22 +102,19 @@ $ExecFunctions = {
             [parameter(Mandatory=$true)] [String] $Command
         )
 
-        $result, $commandOut = TestCommand -Command $Command
+        $status, $duration, $commandOut = TestCommand -Command $Command
+        $duration = ("{0,6:n0}" -f $duration)
 
-        if ($result -eq [CommandStatus]::Succeeded) {
-            ExecCommandText -Command $Command
-            Write-Output $commandOut
-            $cmdLog = $Command
+        ExecCommandText -Command $Command
+        if ($status -eq [CommandStatus]::Success) {
+            $logMsg = "($duration ms) $Command"
         } else {
-            Write-Output "[$result]"
-            Write-Output "$Command"
-            Write-Output "$commandOut"
-            Write-Output "`n`n"
-
-            $cmdLog = "[$result] $Command"
+            $logMsg = "($duration ms) [$status] $Command"
+            Write-Output "[$status]"
         }
+        Write-Output "$commandOut"
 
-        Write-CmdLog "$cmdLog"
+        Write-CmdLog $logMsg
     } # ExecCommand()
 
     function ExecCommands {
@@ -181,17 +181,16 @@ function TryCmd {
 function Write-CmdLog {
     [CmdletBinding()]
     Param(
-        [parameter(Mandatory=$true)] [String] $CmdLog
+        [parameter(Mandatory=$false)] [String] $CmdLog
     )
 
     $logColor = [ConsoleColor]::White
-
-    switch -regex ($CmdLog) {
-        "^\[Failed\].*" {
+    switch -Wildcard ($CmdLog) {
+        "*``[Failed``]*" {
             $logColor = [ConsoleColor]::Yellow
             break
         }
-        "^\[Unavailable\].*" {
+        "*``[Unavailable``]*" {
             $logColor = [ConsoleColor]::Gray
             break
         }
@@ -2383,10 +2382,10 @@ function Get-NetView {
         # Wait for threads to complete
         Show-Threads -Threads $threads
     } catch {
-        $msg = $($error[0] | Out-String)
+        $msg = $($_ | Out-String)
         ExecControlError -OutDir $workDir -Function "Get-NetView" -Message $msg
 
-        throw $error[0]
+        throw $_
     } finally {
         Close-GlobalThreadPool
 


### PR DESCRIPTION
Console output is captured to Get-NetView.log, which will now include command durations.

Preview:
```
(   145 ms) [Failed] Get-VMHostNumaNodeStatus
(    94 ms) Get-VMSystemSwitchExtension | Format-List -Property *
(   326 ms) Get-VMSystemSwitchExtensionSwitchFeature | Format-List -Property *
(   116 ms) Get-VMSystemSwitchExtensionPortFeature | Format-List -Property *
...
```