### PR TITLE
Avoid identifying non-Physical NICs as pNICs, fix #28

### DIFF
--- a/Get-NetView.psm1
+++ b/Get-NetView.psm1
@@ -287,8 +287,7 @@ function Show-Threads {
             $thread.Powershell.Streams.Information | foreach {Write-CmdLog "$_"}
             $thread.Powershell.Streams.Information.Clear()
 
-            if ($thread.AsyncResult.IsCompleted)
-            {
+            if ($thread.AsyncResult.IsCompleted) {
                 # Accessing Streams.Error blocks until thread is completed
                 $thread.Powershell.Streams.Error | Out-Host
                 $thread.Powershell.Streams.Error.Clear()
@@ -517,109 +516,108 @@ function NetAdapterWorker {
 
     $file = "Get-NetAdapter.txt"
     [String []] $cmds = "Get-NetAdapter -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
-                        "Get-NetAdapter -Name ""$name"" -IncludeHidden | Format-List  -Property *"
+                        "Get-NetAdapter -Name ""$name"" -IncludeHidden | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterAdvancedProperty.txt"
-    [String []] $cmds = "Get-NetAdapterAdvancedProperty -Name ""$name"" -AllProperties | Sort-Object RegistryKeyword | Format-Table -AutoSize | Out-String -Width $columns",
-                        "Get-NetAdapterAdvancedProperty -Name ""$name"" -AllProperties -IncludeHidden | Sort-Object RegistryKeyword | Format-Table -AutoSize | Out-String -Width $columns",
-                        "Get-NetAdapterAdvancedProperty -Name ""$name"" -AllProperties -IncludeHidden | Format-List  -Property *",
-                        "Get-NetAdapterAdvancedProperty -Name ""$name"" -AllProperties -IncludeHidden | Format-Table  -Property * | Out-String -Width $columns"
+    [String []] $cmds = "Get-NetAdapterAdvancedProperty -Name ""$name"" -AllProperties -IncludeHidden | Sort-Object RegistryKeyword | Format-Table -AutoSize | Out-String -Width $columns",
+                        "Get-NetAdapterAdvancedProperty -Name ""$name"" -AllProperties -IncludeHidden | Format-List -Property *",
+                        "Get-NetAdapterAdvancedProperty -Name ""$name"" -AllProperties -IncludeHidden | Format-Table -Property * | Out-String -Width $columns"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterBinding.txt"
     [String []] $cmds = "Get-NetAdapterBinding -Name ""$name"" -AllBindings -IncludeHidden | Sort-Object ComponentID | Out-String -Width $columns",
-                        "Get-NetAdapterBinding -Name ""$name"" -AllBindings -IncludeHidden | Format-List  -Property *"
+                        "Get-NetAdapterBinding -Name ""$name"" -AllBindings -IncludeHidden | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterChecksumOffload.txt"
     [String []] $cmds = "Get-NetAdapterChecksumOffload -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
-                        "Get-NetAdapterChecksumOffload -Name ""$name"" -IncludeHidden | Format-List  -Property *"
+                        "Get-NetAdapterChecksumOffload -Name ""$name"" -IncludeHidden | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterLso.txt"
     [String []] $cmds = "Get-NetAdapterLso -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
-                        "Get-NetAdapterLso -Name ""$name"" -IncludeHidden | Format-List  -Property *"
+                        "Get-NetAdapterLso -Name ""$name"" -IncludeHidden | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterRss.txt"
     [String []] $cmds = "Get-NetAdapterRss -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
-                        "Get-NetAdapterRss -Name ""$name"" -IncludeHidden | Format-List  -Property *"
+                        "Get-NetAdapterRss -Name ""$name"" -IncludeHidden | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterStatistics.txt"
     [String []] $cmds = "Get-NetAdapterStatistics -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
-                        "Get-NetAdapterStatistics -Name ""$name"" -IncludeHidden | Format-List  -Property *"
+                        "Get-NetAdapterStatistics -Name ""$name"" -IncludeHidden | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterEncapsulatedPacketTaskOffload.txt"
     [String []] $cmds = "Get-NetAdapterEncapsulatedPacketTaskOffload -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
-                        "Get-NetAdapterEncapsulatedPacketTaskOffload -Name ""$name"" -IncludeHidden | Format-List  -Property *"
+                        "Get-NetAdapterEncapsulatedPacketTaskOffload -Name ""$name"" -IncludeHidden | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterHardwareInfo.txt"
     [String []] $cmds = "Get-NetAdapterHardwareInfo -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
-                        "Get-NetAdapterHardwareInfo -Name ""$name"" -IncludeHidden | Format-List  -Property *"
+                        "Get-NetAdapterHardwareInfo -Name ""$name"" -IncludeHidden | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterIPsecOffload.txt"
     [String []] $cmds = "Get-NetAdapterIPsecOffload -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
-                        "Get-NetAdapterIPsecOffload -Name ""$name"" -IncludeHidden | Format-List  -Property *"
+                        "Get-NetAdapterIPsecOffload -Name ""$name"" -IncludeHidden | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterPowerManagement.txt"
     [String []] $cmds = "Get-NetAdapterPowerManagement -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
-                        "Get-NetAdapterPowerManagement -Name ""$name"" -IncludeHidden | Format-List  -Property *"
+                        "Get-NetAdapterPowerManagement -Name ""$name"" -IncludeHidden | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterQos.txt"
     [String []] $cmds = "Get-NetAdapterQos -Name ""$name"" -IncludeHidden -ErrorAction SilentlyContinue | Out-String -Width $columns",
-                        "Get-NetAdapterQos -Name ""$name"" -IncludeHidden -ErrorAction SilentlyContinue | Format-List  -Property *"
+                        "Get-NetAdapterQos -Name ""$name"" -IncludeHidden -ErrorAction SilentlyContinue | Format-List -Property *"
     ExecCommands -OutDir $dir -File $file -Commands $cmds # Get-NetAdapterQos has severe concurrency issues
 
     $file = "Get-NetAdapterRdma.txt"
     [String []] $cmds = "Get-NetAdapterRdma -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
-                        "Get-NetAdapterRdma -Name ""$name"" -IncludeHidden | Format-List  -Property *"
+                        "Get-NetAdapterRdma -Name ""$name"" -IncludeHidden | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterPacketDirect.txt"
     [String []] $cmds = "Get-NetAdapterPacketDirect -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
-                        "Get-NetAdapterPacketDirect -Name ""$name"" -IncludeHidden | Format-List  -Property *"
+                        "Get-NetAdapterPacketDirect -Name ""$name"" -IncludeHidden | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterRsc.txt"
     [String []] $cmds = "Get-NetAdapterRsc -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
-                        "Get-NetAdapterRsc -Name ""$name"" -IncludeHidden | Format-List  -Property *"
+                        "Get-NetAdapterRsc -Name ""$name"" -IncludeHidden | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterSriov.txt"
     [String []] $cmds = "Get-NetAdapterSriov -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
-                        "Get-NetAdapterSriov -Name ""$name"" -IncludeHidden | Format-List  -Property *"
+                        "Get-NetAdapterSriov -Name ""$name"" -IncludeHidden | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterSriovVf.txt"
     [String []] $cmds = "Get-NetAdapterSriovVf -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
-                        "Get-NetAdapterSriovVf -Name ""$name"" -IncludeHidden | Format-List  -Property *"
+                        "Get-NetAdapterSriovVf -Name ""$name"" -IncludeHidden | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterUso.txt"
     [String []] $cmds = "Get-NetAdapterUso -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
-                        "Get-NetAdapterUso -Name ""$name"" -IncludeHidden | Format-List  -Property *"
+                        "Get-NetAdapterUso -Name ""$name"" -IncludeHidden | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterVmq.txt"
     [String []] $cmds = "Get-NetAdapterVmq -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
-                        "Get-NetAdapterVmq -Name ""$name"" -IncludeHidden | Format-List  -Property *"
+                        "Get-NetAdapterVmq -Name ""$name"" -IncludeHidden | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterVmqQueue.txt"
     [String []] $cmds = "Get-NetAdapterVmqQueue -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
-                        "Get-NetAdapterVmqQueue -Name ""$name"" -IncludeHidden | Format-List  -Property *"
+                        "Get-NetAdapterVmqQueue -Name ""$name"" -IncludeHidden | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterVPort.txt"
     [String []] $cmds = "Get-NetAdapterVPort -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
-                        "Get-NetAdapterVPort -Name ""$name"" -IncludeHidden | Format-List  -Property *"
+                        "Get-NetAdapterVPort -Name ""$name"" -IncludeHidden | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 } # NetAdapterWorker()
 

--- a/Get-NetView.psm1
+++ b/Get-NetView.psm1
@@ -637,16 +637,18 @@ function NetAdapterWorkerPrepare {
     $dir  = $OutDir
 
     # Create dir for each NIC
-    $nic     = Get-NetAdapter -Name $name -IncludeHidden
-    $idx     = $nic.InterfaceIndex
-    $desc    = $nic.InterfaceDescription
-    $title   = "pNic.$idx.$name"
+    $nic   = Get-NetAdapter -Name $name -IncludeHidden
+    $type  = if (Get-NetAdapterHardwareInfo -Name $name -IncludeHidden -ErrorAction "SilentlyContinue") {"pNIC"} else {"NIC"}
+    $idx   = $nic.InterfaceIndex
+    $desc  = $nic.InterfaceDescription
+    $title = "$type.$idx.$name"
+
     if ("$desc") {
         $title = "$title.$desc"
     }
 
     if ($nic.Hidden) {
-        $dir = Join-Path $dir "pNic.Hidden"
+        $dir = Join-Path $dir "NIC.Hidden"
     }
     $dir = Join-Path $dir $(ConvertTo-Filename $title.Trim())
     New-Item -ItemType directory -Path $dir | Out-Null
@@ -2454,12 +2456,8 @@ function EnvCreate {
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
-    # Attempt to create working directory, fail gracefully otherwise
-    try {
-        New-Item -ItemType directory -Path $OutDir -ErrorAction Stop | Out-Null
-    } catch {
-        throw "Get-NetView : Failed to create directory ""$OutDir"" because " + $error[0]
-    }
+    # Attempt to create working directory, stopping on failure.
+    New-Item -ItemType directory -Path $OutDir -ErrorAction Stop | Out-Null
 } # EnvCreate()
 
 function Initialization {

--- a/Get-NetView.psm1
+++ b/Get-NetView.psm1
@@ -127,6 +127,11 @@ $ExecFunctions = {
 
         $out = (Join-Path -Path $OutDir -ChildPath $File)
         $($Commands | foreach {ExecCommand -Command $_}) | Out-File -Encoding ascii -Append $out
+
+        # With high-concurreny, WMI-based cmdlets sometimes output in an
+        # incorrect format or with missing fields. Somehow, this helps
+        # reduce the frequency of the problem.
+        $null = Get-NetAdapter
     } # ExecCommands()
 } # $ExecFunctions
 
@@ -571,8 +576,8 @@ function NetAdapterWorker {
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterQos.txt"
-    [String []] $cmds = "Get-NetAdapterQos -Name ""$name"" -IncludeHidden -ErrorAction SilentlyContinue | Out-String -Width $columns",
-                        "Get-NetAdapterQos -Name ""$name"" -IncludeHidden -ErrorAction SilentlyContinue | Format-List -Property *"
+    [String []] $cmds = "Get-NetAdapterQos -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
+                        "Get-NetAdapterQos -Name ""$name"" -IncludeHidden | Format-List -Property *"
     ExecCommands -OutDir $dir -File $file -Commands $cmds # Get-NetAdapterQos has severe concurrency issues
 
     $file = "Get-NetAdapterRdma.txt"


### PR DESCRIPTION
- Avoid identifying non-Physical NICs as pNIC
- Workaround (?) output issue with WMI and high-concurrency.
- Remove duplicate `Get-NetAdapterAdvancedProperty` call.
- Remove legacy ErrorAction usage from `Get-NetAdapterQos`.
- Remove legacy try/catch from `EnvCreate`
- For both of above, they are superseded by existing error handling.