### PR TITLE
Copy fw trace files for Mellanox WinOF-2 devices

### DIFF
--- a/Get-NetView.psm1
+++ b/Get-NetView.psm1
@@ -1123,7 +1123,8 @@ function MellanoxDetailPerNic {
                             "$env:windir\Temp\Native*$deviceLocation*.log",
                             "$env:windir\Temp\Master*$deviceLocation*.log",
                             "$env:windir\Temp\ML?X5*$deviceLocation*.log",
-                            "$env:windir\Temp\mlx5*$deviceLocation*.log"
+                            "$env:windir\Temp\mlx5*$deviceLocation*.log",
+                            "$env:windir\Temp\FwTrace"
         ExecCopyItemsAsync -OutDir $dir -File $file -Paths $paths -Destination $destination
     }
 } # MellanoxDetailPerNic()


### PR DESCRIPTION
Hi Omar, Tom,

I would like to submit a change to copy FwTrace files for Mellanox WinOF-2 adapters. Could you please review the change and add it?

Thanks,
Rhythm