### PR TITLE
Fix #34, Calculate command execution time statistics

### DIFF
--- a/Get-NetView.psm1
+++ b/Get-NetView.psm1
@@ -2482,8 +2482,8 @@ function LogPostProcess {
     $stdDev = [Math]::Round([Math]::Sqrt($variance), 2)
     $timeSec = [Math]::Round($stats.Sum / 1000, 2)
 
-    Write-Output "Average = $roundedAvg ms, Median = $lazyMedian ms, StdDev = $stdDev ms, Sum = $timeSec s" | Out-File -Encoding ascii -Append $out
-    Write-Output $table | Out-File -Encoding ascii -Append $out
+    Write-Output "Average = $roundedAvg ms, Median = $lazyMedian ms, StdDev = $stdDev ms, Sum = $timeSec s, Count = $($stats.Count)" | Out-File -Encoding ascii -Append $out
+    Write-Output $table | Out-String -Width $columns | Out-File -Encoding ascii -Append $out
 } # LogPostProcess()
 
 #
@@ -2637,7 +2637,7 @@ function Completion {
 
         LogPostProcess -OutDir $logDir
     } catch {
-        Write-Output "Stop-Transcript failed" | Out-File -Encoding ascii -Append "$Src\Get-NetView.log"
+        Write-Output "Stop-Transcript failed" | Out-File -Encoding ascii -Append "$logDir\Get-NetView.log"
     }
 
     Write-Progress -Activity $Global:FinishActivity -Status "Creating zip..."

--- a/Get-NetView.psm1
+++ b/Get-NetView.psm1
@@ -2438,10 +2438,7 @@ function Sanity {
         [parameter(Mandatory=$true)] [Hashtable] $Params
     )
 
-    $dir  = (Join-Path -Path $OutDir -ChildPath "Sanity")
-    New-Item -ItemType directory -Path $dir | Out-Null
-
-    Write-Progress -Activity $Global:FinishActivity -Status "Processing output..."
+    $dir = $OutDir
 
     $file = "Get-ChildItem.txt"
     [String []] $cmds = "Get-ChildItem -Path $OutDir -Exclude Get-NetView.log -File -Recurse | Get-FileHash -Algorithm SHA1 | Format-Table -AutoSize | Out-String -Width $columns"
@@ -2457,6 +2454,37 @@ function Sanity {
     [String []] $cmds = "Get-FileHash -Path ""$PSCommandPath"" -Algorithm SHA1 | Format-List -Property * | Out-String -Width $columns"
     ExecCommands -OutDir $dir -File $file -Commands $cmds
 } # Sanity()
+
+function LogPostProcess {
+    [CmdletBinding()]
+    Param(
+        [parameter(Mandatory=$true)] [String] $OutDir
+    )
+
+    $dir = $OutDir
+    $file = "Command-Time.log"
+    $out = Join-Path $dir $file
+
+    $cmdData = Get-Content "$dir\Get-NetView.log" | where {$_ -like "(* ms)*"}
+    $table = $cmdData | foreach {
+        $time, $cmd = ($_ -replace "^\(\s*","") -split " ms\) "
+        [PSCustomObject] @{
+            "Time (ms)" = $time -as [Int]
+            "Command" = $cmd
+        }
+    }
+    $table = $table | sort -Property "Time (ms)" -Descending
+
+    $stats = $table."Time (ms)" | measure -Average -Sum
+    $roundedAvg = [Math]::Round($stats.Average, 2)
+    $lazyMedian = $table."Time (ms)"[$table.Count / 2]
+    $variance = ($table."Time (ms)" | foreach {[Math]::pow($_ - $stats.Average, 2)} | measure -Average).Average
+    $stdDev = [Math]::Round([Math]::Sqrt($variance), 2)
+    $timeSec = [Math]::Round($stats.Sum / 1000, 2)
+
+    Write-Output "Average = $roundedAvg ms, Median = $lazyMedian ms, StdDev = $stdDev ms, Sum = $timeSec s" | Out-File -Encoding ascii -Append $out
+    Write-Output $table | Out-File -Encoding ascii -Append $out
+} # LogPostProcess()
 
 #
 # Setup & Validation Functions
@@ -2570,6 +2598,15 @@ function Completion {
         [parameter(Mandatory=$true)] [String] $Src
     )
 
+    $logDir  = (Join-Path -Path $Src -ChildPath "_Logs")
+    New-Item -ItemType directory -Path $logDir | Out-Null
+
+    Close-GlobalThreadPool
+
+    Write-Progress -Activity $Global:FinishActivity -Status "Processing output..."
+    Sanity -OutDir $logDir -Params $PSBoundParameters
+
+    # Collect statistics
     $timestamp = $start | Get-Date -f yyyy.MM.dd_hh.mm.ss
 
     $dirs = (Get-ChildItem $Src -Recurse | Measure-Object -Property length -Sum) # out folder size
@@ -2594,10 +2631,14 @@ function Completion {
     Write-Host "$($delta.Minutes) Min $($delta.Seconds) Sec"
     Write-Host ""
 
-    TryCmd {Stop-Transcript}
+    try {
+        Stop-Transcript
+        Move-Item -Path "$Src\Get-NetView.log" -Destination "$logDir\Get-NetView.log"
 
-    # Sort Get-NetView.log by sub-command execution time
-    Get-Content $Src\Get-NetView.log | Sort-Object -Descending > $Src\Get-NetView-Time.Log
+        LogPostProcess -OutDir $logDir
+    } catch {
+        Write-Output "Stop-Transcript failed" | Out-File -Encoding ascii -Append "$Src\Get-NetView.log"
+    }
 
     Write-Progress -Activity $Global:FinishActivity -Status "Creating zip..."
     $outzip = "$Src-$timestamp.zip"
@@ -2750,9 +2791,6 @@ function Get-NetView {
 
         throw $_
     } finally {
-        Close-GlobalThreadPool
-
-        Sanity -OutDir $workDir -Params $PSBoundParameters
         Completion -Src $workDir
     }
 } # Get-NetView


### PR DESCRIPTION
- Move `Close-GlobalThreadPool`, and `Sanity` to `Completion` function to better mirror `Initialize`
- Move logs and metadata to the `_Logs` folder (Q: "Where is the log?" A: "In the logs folder." vs A: "Its the file in the root folder named Get-NetView.log.")
- Calculate command execution statistics (Avg, Median, etc.).

Command-Time.log Preview:
```
Average = 413.6 ms, Median = 73 ms, StdDev = 4529.82 ms, Sum = 451.65 s, Count = 1092

Time (ms) Command                                                                                                                                                                                                                  
--------- -------                                                                                                                                                                                                                  
   127445 netsh trace diagnose scenario=NetworkSnapshot mode=Telemetry saveSessionTrace=yes report=yes ReportFile=C:\Users\thmolenh\Desktop\msdbg.THMOLENH\Netsh\Snapshot.cab                                                      
    52128 typeperf -cf C:\Users\thmolenh\Desktop\msdbg.THMOLENH\Counters\CounterDetail.InstancesToQuery.txt -sc 10 -si 5 -f CSV -o C:\Users\thmolenh\Desktop\msdbg.THMOLENH\Counters\CounterDetail.csv > $null                     
    40971 Get-WindowsDriver -Online -All                                                                                                                                                                                           
    40057 Get-WindowsEdition -Online                                                                                                                                                                                               
     9333 typeperf -qx                          
...
```