### PR TITLE
Transcript output points user to incorrect log location

### DIFF
--- a/Get-NetView.psm1
+++ b/Get-NetView.psm1
@@ -2645,9 +2645,9 @@ function Completion {
     Write-Host ""
 
     try {
-        Stop-Transcript
+        Stop-Transcript | Out-Null
         Move-Item -Path "$Src\Get-NetView.log" -Destination "$logDir\Get-NetView.log"
-
+        Write-Output "Transcript stopped, output file is $logDir\Get-NetView.log"
         LogPostProcess -OutDir $logDir
     } catch {
         Write-Output "Stop-Transcript failed" | Out-File -Encoding ascii -Append "$logDir\Get-NetView.log"


### PR DESCRIPTION
[#45](https://github.com/microsoft/Get-NetView/issues/45)
Simple change so that the last output an end user sees points to the correct log location.