### PR TITLE
remove clear-host

### DIFF
--- a/Get-NetView.psm1
+++ b/Get-NetView.psm1
@@ -2607,7 +2607,6 @@ function Initialize {
     EnvDestroy $OutDir
     EnvCreate $OutDir
 
-    Clear-Host
     Start-Transcript -Path "$OutDir\Get-NetView.log"
 
     if ($ExecutionRate -lt 1) {


### PR DESCRIPTION
- Remove `Clear-Host` as it wipes critical details that might have been executed on environment previously before executing `Get-NetView` that is then lost. 