### PR TITLE
Fix command for ATC cluster intent ops

### DIFF
--- a/Get-NetView.psm1
+++ b/Get-NetView.psm1
@@ -2262,9 +2262,9 @@ function ATCDetail {
 
     Write-Progress -Activity $Global:QueueActivity -Status "Processing $($MyInvocation.MyCommand.Name)"
 
-    $intent = Get-Command "Get-NetIntent" -ErrorAction "SilentlyContinue"
-    $cluster = Get-Command "Get-Cluster" -ErrorAction "SilentlyContinue"
-    if (-not ($intent -or $cluster)) {
+    $intentCmd = Get-Command "Get-NetIntent" -ErrorAction "SilentlyContinue"
+    $clusterCmd = Get-Command "Get-Cluster" -ErrorAction "SilentlyContinue"
+    if (-not ($intentCmd -or $clusterCmd)) {
         return
     }
 
@@ -2272,7 +2272,7 @@ function ATCDetail {
     New-Item -ItemType directory -Path $dir | Out-Null
 
     # Local Intents
-    if ($intent) {
+    if ($intentCmd) {
         $file = "Get-NetIntent_Standalone.txt"
         [String []] $cmds = "Get-NetIntent"
         ExecCommands -OutDir $dir -File $file -Commands $cmds
@@ -2287,7 +2287,8 @@ function ATCDetail {
     }
 
     # Cluster Intents
-    if ($cluster) {
+    if ($clusterCmd) {
+        $cluster = TryCmd { Get-Cluster }
         $file = "Get-NetIntent_Cluster.txt"
         [String []] $cmds = "Get-NetIntent -ClusterName $($cluster.Name)"
         ExecCommands -OutDir $dir -File $file -Commands $cmds


### PR DESCRIPTION
Currently, the cluster versions of the ATC detail commands fail (from Get-NetIntent_cluster.txt):

```
Get-NetIntent -ClusterName Get-Cluster
[Failed]
Get-NetworkIntentRequestFromStore : Exception calling "ReadIntentRequestFromStore" with "2" argument(s): "Failed to open local cluster"
At C:\Windows\system32\WindowsPowerShell\v1.0\Modules\NetworkATC\NetworkAtc.psm1:1765 char:13
+             Get-NetworkIntentRequestFromStore -IsCluster $IsCluster - ...
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Get-NetworkIntentRequestFromStore], MethodInvocationException
    + FullyQualifiedErrorId : Win32Exception,Get-NetworkIntentRequestFromStore
```

It looks like it's passing the command *name* currently (i.e. 'Get-Cluster') rather than the cluster name as intended.  This fix executes the command and returns the name property from the result:

```
Get-NetIntent -ClusterName iUzjQsyWTGSl


AdapterAdvancedParametersOverride : FabricManager.NetAdapterAdvancedConfiguration
RssConfigOverride                 : FabricManager.RssConfiguration
QosPolicyOverride                 : FabricManager.QoSPolicy
```