### PR TITLE
query ip subinterfaces and their statistics

### DIFF
--- a/Get-NetView.psm1
+++ b/Get-NetView.psm1
@@ -1881,7 +1881,7 @@ function VfpExtensionDetail {
                                 "vfpctrl.exe /list-rule /port $portGuid",
                                 "vfpctrl.exe /list-space /port $portGuid",
                                 "vfpctrl.exe /list-unified-flow /port $portGuid"
-                                
+
             ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
         }
     }
@@ -2445,9 +2445,11 @@ function NetshDetail {
                         "netsh interface ipv4 show ipstats",
                         "netsh interface ipv4 show tcpstats",
                         "netsh interface ipv4 show udpstats",
+                        "netsh interface ipv4 show subinterface level=verbose",
                         "netsh interface ipv6 show ipstats",
                         "netsh interface ipv6 show tcpstats",
-                        "netsh interface ipv6 show udpstats"
+                        "netsh interface ipv6 show udpstats",
+                        "netsh interface ipv6 show subinterface level=verbose"
     ExecCommands -OutDir $dir -File $file -Commands $cmds
 
     $file = "NetshTrace.txt"
@@ -2607,7 +2609,7 @@ function LocalhostDetail {
 
     $dir = (Join-Path -Path $OutDir -ChildPath "_Localhost") # sort to top
     New-Item -ItemType directory -Path $dir | Out-Null
-  
+
     if (-not $SkipWindowsRegistry) {
         Start-Thread ${function:WindowsRegistryDetail} -Params @{OutDir=$dir}
     }

--- a/Get-NetView.psm1
+++ b/Get-NetView.psm1
@@ -2445,11 +2445,13 @@ function NetshDetail {
                         "netsh interface ipv4 show ipstats",
                         "netsh interface ipv4 show tcpstats",
                         "netsh interface ipv4 show udpstats",
-                        "netsh interface ipv4 show subinterface level=verbose",
+                        "netsh interface ipv4 show subinterfaces level=verbose",
+                        "netsh interface fl48 show virtualinterfaces level=verbose",
                         "netsh interface ipv6 show ipstats",
                         "netsh interface ipv6 show tcpstats",
                         "netsh interface ipv6 show udpstats",
-                        "netsh interface ipv6 show subinterface level=verbose"
+                        "netsh interface ipv6 show subinterfaces level=verbose",
+                        "netsh interface fl68 show virtualinterfaces level=verbose"
     ExecCommands -OutDir $dir -File $file -Commands $cmds
 
     $file = "NetshTrace.txt"


### PR DESCRIPTION
Add queries for IP subinterfaces and FL virtual interfaces at verbose level, which includes unique statistics missing elsewhere.

[Also include automatic trailing whitespace removal]