### PR TITLE
restore last appveyor version

### DIFF
--- a/Get-NetView.psd1
+++ b/Get-NetView.psd1
@@ -12,7 +12,7 @@
 RootModule = 'Get-NetView.psm1'
 
 # Version number of this module.
-ModuleVersion = '2023.6.9.228'
+ModuleVersion = '2023.2.7.226'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Desktop', 'Core'
@@ -129,4 +129,3 @@ PrivateData = @{
 # DefaultCommandPrefix = ''
 
 }
-

--- a/Get-NetView.psm1
+++ b/Get-NetView.psm1
@@ -1,4 +1,4 @@
-$Global:Version = "2023.6.9.228"
+$Global:Version = "2023.2.7.226"
 
 $Script:RunspacePool = $null
 $Script:ThreadList = [Collections.ArrayList]@()


### PR DESCRIPTION
#69 manually edited the module version, which seems to have broken the deployment script. Restore the module version to the last automatic version, and hope the deployer catches up.